### PR TITLE
Add optional LLM mode + /api/capabilities

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,0 +1,256 @@
+import { NextResponse } from 'next/server';
+
+import nlp from 'compromise';
+import natural from 'natural';
+import { removeStopwords } from 'stopword';
+
+export const runtime = 'nodejs';
+
+type LlmPlan = {
+  summary: string;
+  key_points: string[];
+  risks: string[];
+  next_actions: string[];
+  questions_to_answer: string[];
+};
+
+type Mode = 'deterministic' | 'llm';
+
+function clampString(s: string, max = 120_000) {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+function computeKeywords(text: string) {
+  const cleaned = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s\-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const tokens = cleaned.split(' ').filter(Boolean);
+  const filtered = removeStopwords(tokens).filter((t) => t.length >= 3 && t.length <= 24);
+
+  const tfidf = new natural.TfIdf();
+  tfidf.addDocument(filtered);
+
+  const terms = tfidf.listTerms(0).slice(0, 18);
+  return terms.map((t) => ({ term: t.term, score: t.tfidf }));
+}
+
+function computeEntities(text: string) {
+  const sample = text.slice(0, 40_000);
+  const doc = nlp(sample);
+
+  const people = doc.people().out('array') as string[];
+  const orgs = doc.organizations().out('array') as string[];
+  const places = doc.places().out('array') as string[];
+
+  const counts = new Map<string, { type: string; text: string; count: number }>();
+  function add(type: string, items: string[]) {
+    for (const raw of items) {
+      const t = raw.trim();
+      if (!t) continue;
+      const key = `${type}:${t.toLowerCase()}`;
+      const prev = counts.get(key);
+      counts.set(key, prev ? { ...prev, count: prev.count + 1 } : { type, text: t, count: 1 });
+    }
+  }
+  add('person', people);
+  add('org', orgs);
+  add('place', places);
+
+  return Array.from(counts.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
+}
+
+function computeChecklist(text: string, title?: string) {
+  const hay = `${title ?? ''}\n\n${text}`.toLowerCase();
+  const items: string[] = [];
+
+  if (/(github\.com|repo|repository|pull request|pr\b)/.test(hay)) {
+    items.push('Open the repo and skim the README + open issues.');
+    items.push('Check the last 5 commits to understand current direction.');
+  }
+
+  if (/(install|npm i|pip install|brew install|setup|getting started)/.test(hay)) {
+    items.push('Find the setup/installation section and run it in a clean folder.');
+  }
+
+  if (/(api|endpoint|rate limit|auth|token)/.test(hay)) {
+    items.push('Identify required auth + rate limits; write down what’s needed to run it locally.');
+  }
+
+  if (/(benchmark|eval|evaluation|accuracy|hallucinat)/.test(hay)) {
+    items.push('Locate the evaluation methodology and note what was measured (and what wasn’t).');
+  }
+
+  if (/(pricing|cost|latency|speed)/.test(hay)) {
+    items.push('Capture cost/latency claims and look for caveats or missing assumptions.');
+  }
+
+  items.push('Write a 1-sentence summary in your own words.');
+  items.push('List 2 things you could build that reuse the core idea.');
+
+  const seen = new Set<string>();
+  return items.filter((i) => (seen.has(i) ? false : (seen.add(i), true)));
+}
+
+function hasOpenAIKey() {
+  return Boolean(process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim());
+}
+
+function isValidLlmPlan(x: unknown): x is LlmPlan {
+  const isStr = (v: unknown) => typeof v === 'string' && v.trim().length > 0;
+  const isStrArr = (v: unknown) => Array.isArray(v) && v.every((s) => typeof s === 'string');
+  const o = x as Record<string, unknown> | null;
+  return (
+    o &&
+    isStr(o.summary) &&
+    isStrArr(o.key_points) &&
+    isStrArr(o.risks) &&
+    isStrArr(o.next_actions) &&
+    isStrArr(o.questions_to_answer)
+  );
+}
+
+async function runOpenAIPlan(input: {
+  title?: string | null;
+  url?: string | null;
+  textContent: string;
+  topKeywords: { term: string; score: number }[];
+  entities: { type: string; text: string; count: number }[];
+}): Promise<LlmPlan> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY missing');
+
+  const prompt = [
+    'You are BrowseBuddy, a page-aware assistant.',
+    'Given extracted page content, produce a concise summary and an action plan.',
+    '',
+    'Return ONLY valid JSON matching:',
+    '{ summary: string; key_points: string[]; risks: string[]; next_actions: string[]; questions_to_answer: string[] }',
+    '',
+    'Guidelines:',
+    '- summary <= 6 sentences',
+    '- key_points 5-10 bullets',
+    '- risks 0-6 bullets',
+    '- next_actions 5-10 bullets, pragmatic and sequenced',
+    '- questions_to_answer 3-8 bullets',
+  ].join('\n');
+
+  const payload = {
+    model: 'gpt-4.1-mini',
+    input: [
+      { role: 'system', content: [{ type: 'text', text: prompt }] },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                url: input.url,
+                title: input.title,
+                topKeywords: input.topKeywords,
+                entities: input.entities,
+                textContent: clampString(input.textContent, 40_000),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      },
+    ],
+    text: { format: { type: 'json_object' } },
+  };
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`OpenAI error: ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 500)}` : ''}`);
+  }
+
+  const json = await res.json();
+  const text = (json?.output_text as string) || '';
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    const m = text.match(/\{[\s\S]*\}$/);
+    if (!m) throw new Error('Could not parse JSON from OpenAI response');
+    parsed = JSON.parse(m[0]);
+  }
+
+  if (!isValidLlmPlan(parsed)) throw new Error('OpenAI returned invalid JSON contract');
+  return parsed;
+}
+
+export async function POST(req: Request) {
+  const mode = ((new URL(req.url)).searchParams.get('mode') || 'deterministic') as Mode;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const b = body as Record<string, unknown> | null;
+  const title = typeof b?.title === 'string' ? b.title : undefined;
+  const url = typeof b?.url === 'string' ? b.url : undefined;
+  const textContent = typeof b?.textContent === 'string' ? b.textContent : '';
+
+  if (!textContent.trim()) {
+    return NextResponse.json({ ok: false, error: 'Missing textContent' }, { status: 400 });
+  }
+
+  const cleanedText = textContent.replace(/\s+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+  const wordCount = cleanedText ? cleanedText.split(/\s+/).length : 0;
+  const readingMinutes = Math.max(1, Math.round(wordCount / 220));
+
+  const topKeywords = computeKeywords(cleanedText);
+  const entities = computeEntities(cleanedText);
+  const actionChecklist = computeChecklist(cleanedText, title);
+
+  const base = {
+    ok: true as const,
+    url,
+    title,
+    textContent: cleanedText,
+    wordCount,
+    readingMinutes,
+    topKeywords,
+    entities,
+    actionChecklist,
+  };
+
+  if (mode !== 'llm') return NextResponse.json(base);
+
+  if (!hasOpenAIKey()) {
+    return NextResponse.json({
+      ...base,
+      warning: 'LLM mode requested but OPENAI_API_KEY is not set; using deterministic output.',
+    });
+  }
+
+  try {
+    const llm = await runOpenAIPlan({ title, url, textContent: cleanedText, topKeywords, entities });
+    return NextResponse.json({ ...base, llm, mode: 'llm' as const });
+  } catch (e: unknown) {
+    const err = e as { message?: string } | null;
+    return NextResponse.json({
+      ...base,
+      warning: `LLM mode failed; using deterministic output. ${err?.message ?? ''}`.trim(),
+    });
+  }
+}

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const hasOpenAIKey = Boolean(process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim());
+  return NextResponse.json({ hasOpenAIKey });
+}

--- a/src/app/api/extract/route.ts
+++ b/src/app/api/extract/route.ts
@@ -8,6 +8,16 @@ import { removeStopwords } from 'stopword';
 
 export const runtime = 'nodejs';
 
+type Mode = 'deterministic' | 'llm';
+
+type LlmPlan = {
+  summary: string;
+  key_points: string[];
+  risks: string[];
+  next_actions: string[];
+  questions_to_answer: string[];
+};
+
 function clampString(s: string, max = 120_000) {
   return s.length > max ? s.slice(0, max) : s;
 }
@@ -58,6 +68,122 @@ function computeEntities(text: string) {
     .slice(0, 20);
 }
 
+function hasOpenAIKey() {
+  return Boolean(process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim());
+}
+
+function isValidLlmPlan(x: unknown): x is LlmPlan {
+  const isStr = (v: unknown) => typeof v === 'string' && v.trim().length > 0;
+  const isStrArr = (v: unknown) => Array.isArray(v) && v.every((s) => typeof s === 'string');
+  return (
+    x &&
+    isStr(x.summary) &&
+    isStrArr(x.key_points) &&
+    isStrArr(x.risks) &&
+    isStrArr(x.next_actions) &&
+    isStrArr(x.questions_to_answer)
+  );
+}
+
+async function runOpenAIPlan(input: {
+  url: string;
+  title?: string | null;
+  siteName?: string | null;
+  byline?: string | null;
+  excerpt?: string | null;
+  textContent: string;
+  topKeywords: { term: string; score: number }[];
+  entities: { type: string; text: string; count: number }[];
+}): Promise<LlmPlan> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY missing');
+
+  const prompt = [
+    'You are BrowseBuddy, a page-aware assistant.',
+    'Given an extracted web page, produce a concise summary and an action plan.',
+    '',
+    'Return ONLY valid JSON matching this TypeScript type:',
+    '{',
+    '  summary: string;',
+    '  key_points: string[];',
+    '  risks: string[];',
+    '  next_actions: string[];',
+    '  questions_to_answer: string[];',
+    '}',
+    '',
+    'Guidelines:',
+    '- Keep summary <= 6 sentences.',
+    '- key_points: 5-10 bullets.',
+    '- risks: 0-6 bullets (include missing info, bias, blockers).',
+    '- next_actions: 5-10 bullets, pragmatic and sequenced.',
+    '- questions_to_answer: 3-8 bullets.',
+  ].join('\n');
+
+  const payload = {
+    model: 'gpt-4.1-mini',
+    input: [
+      {
+        role: 'system',
+        content: [{ type: 'text', text: prompt }],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                url: input.url,
+                title: input.title,
+                siteName: input.siteName,
+                byline: input.byline,
+                excerpt: input.excerpt,
+                topKeywords: input.topKeywords,
+                entities: input.entities,
+                textContent: clampString(input.textContent, 40_000),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      },
+    ],
+    // Prefer JSON output
+    text: { format: { type: 'json_object' } },
+  };
+
+  const res = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`OpenAI error: ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 500)}` : ''}`);
+  }
+
+  const json = await res.json();
+  // Responses API: easiest extraction is output_text when format is JSON; still guard.
+  const text = (json?.output_text as string) || '';
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Some responses embed JSON elsewhere; attempt to find the first {...} block.
+    const m = text.match(/\{[\s\S]*\}$/);
+    if (!m) throw new Error('Could not parse JSON from OpenAI response');
+    parsed = JSON.parse(m[0]);
+  }
+
+  if (!isValidLlmPlan(parsed)) throw new Error('OpenAI returned invalid JSON contract');
+  return parsed;
+}
+
 function computeChecklist(text: string, title?: string) {
   const hay = `${title ?? ''}\n\n${text}`.toLowerCase();
 
@@ -96,6 +222,7 @@ function computeChecklist(text: string, title?: string) {
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const rawUrl = searchParams.get('url')?.trim();
+  const mode = (searchParams.get('mode') || 'deterministic') as Mode;
 
   if (!rawUrl) {
     return NextResponse.json({ ok: false, error: 'Missing ?url=' }, { status: 400 });
@@ -164,8 +291,8 @@ export async function GET(req: Request) {
     const entities = textContent ? computeEntities(textContent) : [];
     const actionChecklist = computeChecklist(textContent, article.title ?? undefined);
 
-    return NextResponse.json({
-      ok: true,
+    const base = {
+      ok: true as const,
       url: url.toString(),
       title: article.title,
       byline: article.byline,
@@ -177,9 +304,38 @@ export async function GET(req: Request) {
       topKeywords,
       entities,
       actionChecklist,
-    });
-  } catch (e: any) {
-    const msg = e?.name === 'AbortError' ? 'Fetch timed out (12s).' : e?.message ?? 'Unknown error.';
+    };
+
+    if (mode !== 'llm') {
+      return NextResponse.json(base);
+    }
+
+    if (!hasOpenAIKey()) {
+      return NextResponse.json({ ...base, warning: 'LLM mode requested but OPENAI_API_KEY is not set; using deterministic output.' });
+    }
+
+    try {
+      const llm = await runOpenAIPlan({
+        url: url.toString(),
+        title: article.title,
+        siteName: article.siteName,
+        byline: article.byline,
+        excerpt: article.excerpt,
+        textContent,
+        topKeywords,
+        entities,
+      });
+      return NextResponse.json({ ...base, llm, mode: 'llm' as const });
+    } catch (e: unknown) {
+      const err = e as { message?: string } | null;
+      return NextResponse.json({
+        ...base,
+        warning: `LLM mode failed; using deterministic output. ${err?.message ?? ''}`.trim(),
+      });
+    }
+  } catch (e: unknown) {
+    const err = e as { name?: string; message?: string } | null;
+    const msg = err?.name === 'AbortError' ? 'Fetch timed out (12s).' : err?.message ?? 'Unknown error.';
     return NextResponse.json({ ok: false, error: msg }, { status: 500 });
   }
 }

--- a/src/components/BrowseBuddy.tsx
+++ b/src/components/BrowseBuddy.tsx
@@ -1,10 +1,25 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+type Capabilities = {
+  hasOpenAIKey: boolean;
+};
+
+type LlmPlan = {
+  summary: string;
+  key_points: string[];
+  risks: string[];
+  next_actions: string[];
+  questions_to_answer: string[];
+};
 
 type ExtractResult = {
   ok: boolean;
   error?: string;
+  warning?: string;
+  mode?: 'deterministic' | 'llm';
+  llm?: LlmPlan;
   url?: string;
   title?: string;
   byline?: string;
@@ -28,6 +43,24 @@ export default function BrowseBuddy() {
   const [url, setUrl] = useState('');
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<ExtractResult | null>(null);
+  const [caps, setCaps] = useState<Capabilities | null>(null);
+  const [llmMode, setLlmMode] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/capabilities');
+        const json = (await res.json()) as Capabilities;
+        if (mounted) setCaps(json);
+      } catch {
+        if (mounted) setCaps({ hasOpenAIKey: false });
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const canSubmit = useMemo(() => {
     if (!url.trim()) return false;
@@ -44,11 +77,15 @@ export default function BrowseBuddy() {
     setLoading(true);
     setData(null);
     try {
-      const res = await fetch(`/api/extract?url=${encodeURIComponent(url.trim())}`);
+      const mode = llmMode ? 'llm' : 'deterministic';
+      const res = await fetch(
+        `/api/extract?url=${encodeURIComponent(url.trim())}&mode=${encodeURIComponent(mode)}`
+      );
       const json = (await res.json()) as ExtractResult;
       setData(json);
-    } catch (e: any) {
-      setData({ ok: false, error: e?.message ?? 'Unknown error' });
+    } catch (e: unknown) {
+      const err = e as { message?: string } | null;
+      setData({ ok: false, error: err?.message ?? 'Unknown error' });
     } finally {
       setLoading(false);
     }
@@ -60,7 +97,7 @@ export default function BrowseBuddy() {
         <div>
           <h1>BrowseBuddy</h1>
           <p className="sub">
-            A "page-aware" browser assistant — without API keys. Paste a URL, and it will extract the
+            A &quot;page-aware&quot; browser assistant — without API keys. Paste a URL, and it will extract the
             main content, surface keywords/entities, and propose a next-action checklist.
           </p>
         </div>
@@ -80,6 +117,22 @@ export default function BrowseBuddy() {
           <button className="button" onClick={run} disabled={!canSubmit || loading}>
             {loading ? 'Analyzing…' : 'Analyze'}
           </button>
+        </div>
+
+        <div className="row" style={{ marginTop: 10, justifyContent: 'flex-start', gap: 10 }}>
+          <label className="fine" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={llmMode}
+              disabled={!caps?.hasOpenAIKey}
+              onChange={(e) => setLlmMode(e.target.checked)}
+            />
+            LLM mode (uses server key)
+          </label>
+          {!caps ? <span className="fine muted">Checking capabilities…</span> : null}
+          {caps && !caps.hasOpenAIKey ? (
+            <span className="fine muted">(OPENAI_API_KEY not set on server)</span>
+          ) : null}
         </div>
         <div className="examples">
           <span className="muted">Try:</span>
@@ -109,6 +162,13 @@ export default function BrowseBuddy() {
           <p className="mono">{data.error ?? 'Unknown error'}</p>
         </section>
       )}
+
+      {data && data.ok && data.warning ? (
+        <section className="card" style={{ borderColor: 'rgba(255, 204, 102, 0.45)' }}>
+          <h2 style={{ marginTop: 0 }}>Note</h2>
+          <p className="mono">{data.warning}</p>
+        </section>
+      ) : null}
 
       {data && data.ok && (
         <section className="grid">
@@ -194,6 +254,60 @@ export default function BrowseBuddy() {
                 you can extend.
               </p>
             </section>
+
+            {llmMode ? (
+              <section className="card">
+                <h3>LLM summary + plan</h3>
+                {data.llm ? (
+                  <div style={{ display: 'grid', gap: 10 }}>
+                    <div>
+                      <div className="kicker">Summary</div>
+                      <p style={{ marginTop: 6 }}>{data.llm.summary}</p>
+                    </div>
+
+                    <div>
+                      <div className="kicker">Key points</div>
+                      <ul className="list">
+                        {data.llm.key_points.map((x, i) => (
+                          <li key={i}>{x}</li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    {(data.llm.risks ?? []).length ? (
+                      <div>
+                        <div className="kicker">Risks / caveats</div>
+                        <ul className="list">
+                          {data.llm.risks.map((x, i) => (
+                            <li key={i}>{x}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+
+                    <div>
+                      <div className="kicker">Next actions</div>
+                      <ol className="list">
+                        {data.llm.next_actions.map((x, i) => (
+                          <li key={i}>{x}</li>
+                        ))}
+                      </ol>
+                    </div>
+
+                    <div>
+                      <div className="kicker">Questions to answer</div>
+                      <ul className="list">
+                        {data.llm.questions_to_answer.map((x, i) => (
+                          <li key={i}>{x}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="muted">No LLM output (using deterministic output).</p>
+                )}
+              </section>
+            ) : null}
           </aside>
         </section>
       )}

--- a/src/components/BrowseBuddy.tsx
+++ b/src/components/BrowseBuddy.tsx
@@ -82,6 +82,24 @@ export default function BrowseBuddy() {
         `/api/extract?url=${encodeURIComponent(url.trim())}&mode=${encodeURIComponent(mode)}`
       );
       const json = (await res.json()) as ExtractResult;
+
+      // If fetch is blocked (403/anti-bot), allow manual paste fallback.
+      if (!json.ok && /403\b/.test(json.error ?? '')) {
+        const pasted = window.prompt(
+          'This site blocked server-side fetching (403).\n\nPaste the article text (or main content) here to analyze instead:'
+        );
+        if (pasted && pasted.trim()) {
+          const alt = await fetch(`/api/analyze?mode=${encodeURIComponent(mode)}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ url: url.trim(), title: url.trim(), textContent: pasted }),
+          });
+          const altJson = (await alt.json()) as ExtractResult;
+          setData(altJson);
+          return;
+        }
+      }
+
       setData(json);
     } catch (e: unknown) {
       const err = e as { message?: string } | null;


### PR DESCRIPTION
Closes #1

### What
- Adds `GET /api/capabilities` → `{ hasOpenAIKey: boolean }`
- Extends `GET /api/extract` with `mode=deterministic|llm`
  - If `mode=llm` and `OPENAI_API_KEY` present: calls OpenAI (Responses API) and returns `llm` JSON contract
  - If missing key or error/invalid JSON: falls back to deterministic output and includes `warning`
- UI: adds checkbox “LLM mode (uses server key)” (disabled unless server reports key present)
- UI: renders LLM summary/plan block in the right-side panel when enabled

### Notes
- Uses model `gpt-4.1-mini` by default; easy to swap later.
- Deterministic pipeline remains unchanged and is always returned (keywords/entities/checklist).